### PR TITLE
Add percentage changed based regression check

### DIFF
--- a/apkdiff/ApkDescription.cs
+++ b/apkdiff/ApkDescription.cs
@@ -230,6 +230,15 @@ namespace apkdiff {
 						}
 					}
 
+					if (ApkDiff.FileRegressionThresholdPercentage != 0) {
+						double originalValue = other.Entries[diff.Key].Size;
+						var change = diff.Value / originalValue * 100;
+						if (change > ApkDiff.FileRegressionThresholdPercentage || (ApkDiff.DecreaseIsRegression && change < -ApkDiff.FileRegressionThresholdPercentage)) {
+							Program.Error ($"File '{diff.Key}' has changed by {diff.Value:#,0} bytes ({change:#,0.00} %). This exceeds the threshold of {ApkDiff.FileRegressionThresholdPercentage:#,0.00} %.");
+							ApkDiff.RegressionCount++;
+						}
+					}
+
 					if (!flat && comparingApks && !single)
 						CompareEntries (new KeyValuePair<string, FileProperties> (diff.Key, Entries [diff.Key]), new KeyValuePair<string, FileProperties> (diff.Key, other.Entries [diff.Key]), other, entryDiff);
 					else if (entryDiff is AssemblyDiff) {

--- a/apkdiff/ApkDiff.cs
+++ b/apkdiff/ApkDiff.cs
@@ -19,6 +19,8 @@ namespace apkdiff
 		public static long ApkRegressionThreshold;
 		public static bool DecreaseIsRegression;
 		public static int RegressionCount;
+		public static double ApkRegressionThresholdPercentage;
+		public static double FileRegressionThresholdPercentage;
 
 		static ApkDiff ()
 		{
@@ -42,6 +44,14 @@ namespace apkdiff
 						RegressionCount++;
 					} else if (DecreaseIsRegression && (desc1.PackageSize - desc2.PackageSize) > ApkRegressionThreshold) {
 						Error ($"PackageSize decrease {desc1.PackageSize - desc2.PackageSize:#,0} is {desc1.PackageSize - desc2.PackageSize - ApkRegressionThreshold:#,0} bytes more than the threshold {ApkRegressionThreshold:#,0}. apk1 size: {desc1.PackageSize:#,0} bytes, apk2 size: {desc2.PackageSize:#,0} bytes.");
+						RegressionCount++;
+					}
+				}
+				if (ApkRegressionThresholdPercentage != 0) {
+					double diff = desc2.PackageSize - desc1.PackageSize;
+					var change =  diff / desc1.PackageSize * 100;
+					if (change > ApkRegressionThresholdPercentage || (DecreaseIsRegression && change < -ApkRegressionThresholdPercentage)) {
+						Error ($"PackageSize difference {change:#,0.00} % exceeds the threshold of {ApkRegressionThresholdPercentage:#,0.00} %. apk1 size: {desc1.PackageSize:#,0} bytes, apk2 size: {desc2.PackageSize:#,0} bytes.");
 						RegressionCount++;
 					}
 				}
@@ -94,6 +104,12 @@ namespace apkdiff
 				{ "test-assembly-size-regression=",
 					"Check whether any assembly size increased more than {BYTES}",
 				  v => AssemblyRegressionThreshold = long.Parse (v) },
+				{ "test-apk-percentage-regression=",
+					"Check whether the apk size increased by more than {PERCENT}",
+				  v => ApkRegressionThresholdPercentage = double.Parse (v) },
+				{ "test-content-percentage-regression=",
+					"Check whether any individual file size increased by more than {PERCENT}",
+				  v => FileRegressionThresholdPercentage = double.Parse (v) },
 				{ "s|save-descriptions",
 					"Save .[apk|aab]desc description files next to the package(s) or to the specified path",
 				  v => SaveDescriptions = true },

--- a/apkdiff/Program.cs
+++ b/apkdiff/Program.cs
@@ -5,7 +5,9 @@ using static System.Console;
 
 namespace apkdiff {
 	class Program {
+#pragma warning disable CS0649
 		public static bool SummaryOnly;
+#pragma warning restore CS0649
 		public static bool Verbose;
 		protected static string Name;
 


### PR DESCRIPTION
Adds two new parameters to enable "percentage changed" based regression
testing.  The `--test-apk-percentage-regression` parameter will report
errors if the overall package size changes more than the specified
threshold percentage.  The `--test-content-percentage-regression`
parameter will report an error for every .dll, .so, or .dex file in the
.apk that has a size change that exceeds the specified threshold
percentage.

The following comparison was done against a .NET 6 preview 4 PR build to
test these changes:

    apkdiff --test-apk-percentage-regression=0.25 --test-content-percentage-regression=0.25 --descrease-is-regression BuildReleaseArm64SimpleDotNet.apkdesc com.xamarin.buildreleasearm64-Signed.apk

    Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
    +     111,232 lib/arm64-v8a/libmonosgen-2.0.so
    Error: apkdiff: File 'lib/arm64-v8a/libmonosgen-2.0.so' has changed by 111,232 bytes (3.01 %). This exceeds the threshold of 0.25 %.
    +         118 assemblies/Mono.Android.dll
    +           4 assemblies/System.Runtime.dll
    -           6 assemblies/UnnamedProject.dll
    -          14 assemblies/System.Linq.dll
    -         168 lib/arm64-v8a/libmonodroid.so
    -       1,654 assemblies/System.Private.CoreLib.dll
    Error: apkdiff: File 'assemblies/System.Private.CoreLib.dll' has changed by -1,654 bytes (-0.32 %). This exceeds the threshold of 0.25 %.
    Summary:
    +           0 Other entries 0.00% (of 58,411)
    +           0 Dalvik executables 0.00% (of 316,728)
    -       1,552 Assemblies -0.23% (of 671,690)
    +     111,064 Shared libraries 2.20% (of 5,038,648)
    +      45,056 Package size difference 1.59% (of 2,828,142)
    Error: apkdiff: PackageSize difference 1.59 % exceeds the threshold of 0.25 %. apk1 size: 2,828,142 bytes, apk2 size: 2,873,198 bytes.