### PR TITLE
Sort `Entries` within `apkdesc` files.

### DIFF
--- a/apkdiff/ApkDescription.cs
+++ b/apkdiff/ApkDescription.cs
@@ -26,7 +26,7 @@ namespace apkdiff {
 		ZipArchive Archive;
 
 		[DataMember]
-		readonly Dictionary<string, FileProperties> Entries = new Dictionary<string, FileProperties> ();
+		readonly SortedDictionary<string, FileProperties> Entries = new SortedDictionary<string, FileProperties> ();
 
 		Dictionary<string, (long Difference, long OriginalTotal)> totalDifferences = new Dictionary<string, (long, long)> ();
 


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4613
Context: https://github.com/xamarin/xamarin-android/pull/5887/files#r623486573

Sorting the output makes for smaller patches when `.apkdesc` files
need to be updated.

Use a `SortedDictionary` instead of a `Dictionary` so that the
`Entries` JSON dict is sorted by the filename, not "random".