### PR TITLE
[build] Allow apkdiff to run on net6.0.

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.101
+        dotnet-version: 6.0.100
         source-url: https://nuget.pkg.github.com/<owner>/index.json
       env:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.100
+        dotnet-version: 3.1.101
         source-url: https://nuget.pkg.github.com/<owner>/index.json
       env:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/adiff/adiff.csproj
+++ b/adiff/adiff.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <Company>Microsoft Corporation</Company>
     <Copyright>2020 Microsoft Corporation</Copyright>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RollForward>Major</RollForward>
     <Version>$(ProductVersion)</Version>
     <Authors>Radek Doulik</Authors>
     <OutputType>Exe</OutputType>

--- a/adiff/adiff.csproj
+++ b/adiff/adiff.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Company>Microsoft Corporation</Company>
     <Copyright>2020 Microsoft Corporation</Copyright>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>$(ProductVersion)</Version>
     <Authors>Radek Doulik</Authors>
     <OutputType>Exe</OutputType>

--- a/apkdiff/apkdiff.csproj
+++ b/apkdiff/apkdiff.csproj
@@ -2,7 +2,8 @@
   <PropertyGroup>
     <Company>Microsoft Corporation</Company>
     <Copyright>2020 Microsoft Corporation</Copyright>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RollForward>Major</RollForward>
     <Version>$(ProductVersion)</Version>
     <Authors>Radek Doulik</Authors>
     <OutputType>Exe</OutputType>

--- a/apkdiff/apkdiff.csproj
+++ b/apkdiff/apkdiff.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Company>Microsoft Corporation</Company>
     <Copyright>2020 Microsoft Corporation</Copyright>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>$(ProductVersion)</Version>
     <Authors>Radek Doulik</Authors>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
Context: https://github.com/dotnet/designs/blob/main/accepted/2019/runtime-binding.md#rollforward

Uses the `$(RollForward)` property to allow `adiff` and `apkdiff` to run
against newer versions of .NET if `netcoreapp3.1` is not present.